### PR TITLE
Update Laravel Framework to work with blade templates

### DIFF
--- a/src/frameworks/laravel/index.ts
+++ b/src/frameworks/laravel/index.ts
@@ -14,6 +14,7 @@ class LaravelFramework extends Framework {
 
   languageIds: LanguageId[] = [
     'php',
+    'blade',
   ]
 
   // for visualize the regex, you can use https://regexper.com/


### PR DESCRIPTION
This should allow the extension to work with a couple of VS Code extensions that enable highlighting for Laravel Blade Template files, like https://marketplace.visualstudio.com/items?itemName=onecentlin.laravel-blade