### PR TITLE
fix: Write file with newline at the end of file

### DIFF
--- a/src/utils/File.ts
+++ b/src/utils/File.ts
@@ -101,6 +101,6 @@ export class File {
   }
 
   static encode(string: string, encoding: string, addBOM = true): Buffer {
-    return iconv.encode(string, encoding, { addBOM })
+    return iconv.encode(`${string}\n`, encoding, { addBOM })
   }
 }


### PR DESCRIPTION
Restored the ability to newline at the end of file.  
See. d50fb6ea521bb22ddf1762097335dc8d408b943e

Thank you for wonderful and useful extension!