### PR TITLE
add newer @intlify version of vue-i18n-loader

### DIFF
--- a/src/frameworks/vue-sfc.ts
+++ b/src/frameworks/vue-sfc.ts
@@ -7,6 +7,7 @@ class VueSFCFramework extends Framework {
   detection = {
     packageJSON: [
       '@kazupon/vue-i18n-loader',
+      '@intlify/vue-i18n-loader'
     ],
   }
 


### PR DESCRIPTION
vue-i18n-loader is now maintained at @intlify/vue-i18n-loader