### PR TITLE
UI5 Framework update 2

### DIFF
--- a/examples/by-frameworks/ui5/webapp/i18n/i18n_en.properties
+++ b/examples/by-frameworks/ui5/webapp/i18n/i18n_en.properties
@@ -1,3 +1,4 @@
 steady = Click me!!
 hello = Hello App!
 title = My App
+appTitle = Test Application

--- a/examples/by-frameworks/ui5/webapp/manifest.json
+++ b/examples/by-frameworks/ui5/webapp/manifest.json
@@ -1,0 +1,3 @@
+{
+    "title":"{{appTitle}}"
+}

--- a/src/frameworks/index.ts
+++ b/src/frameworks/index.ts
@@ -49,7 +49,6 @@ export const frameworks: Framework[] = [
 
   // Vue SFC should be the last one
   new VueSFCFramework(),
-  new UI5Framework(),
 ]
 
 export function getFramework(id: string): Framework | undefined {

--- a/src/frameworks/ui5.ts
+++ b/src/frameworks/ui5.ts
@@ -14,6 +14,7 @@ class UI5Framework extends Framework {
   }
 
   languageIds: LanguageId[] = [
+    'json',
     'xml',
     'javascript',
     'typescript',
@@ -23,12 +24,14 @@ class UI5Framework extends Framework {
   usageMatchRegex = [
     '\\{(i18n>{key})\\}',
     'getResourceBundle\\(\\)\\.getText\\([\'"`]({key})[\'"`]',
+    '\\{\\{({key})\\}\\}',
   ]
 
   refactorTemplates(keypath: string, languageId: string) {
     return [
       `{i18n>${keypath}}`,
       `this.getResourceBundle().getText("${keypath}")`,
+      `{{${keypath}}}`,
       keypath,
     ]
   }


### PR DESCRIPTION
This update is to allow i18n translations from "manifest.json"(descriptor file), in which the i18n keys will be in the format of  "{{key}}"
- updated to allow json file
- updated the usagematch regex and refactor templates to allow the above format key.

Please let me know in case of any issues. Thanks in advance!