### PR TITLE
Change settings definition for po-parser

### DIFF
--- a/package.json
+++ b/package.json
@@ -617,7 +617,7 @@
               "json5",
               "yaml",
               "ini",
-              "pot",
+              "po",
               "php",
               "properties"
             ]


### PR DESCRIPTION
I struggled with this for a while when trying to enable the po/pot-parser in the current version of the plugin.

Adding `"i18n-ally.enabledParsers": ["pot"]` in settings resulted in `🧬 Enabled parsers: ` showing up in the logs, and no files were found. Changing this to `"i18n-ally.enabledParsers": ["po"]` on the other hand seems to work fine, and `🧬 Enabled parsers: po` shows up in the logs.

However, VSCode thinks the value should be `pot` rather than `po`, which is incorrect.

<img width="789" alt="image" src="https://user-images.githubusercontent.com/1380307/83272253-381bcb00-a1cb-11ea-823a-e7ca66a41781.png">
