### PR TITLE
Fixed tabStyle being ignored when formatting JSON and JSON5

### DIFF
--- a/src/parsers/json.ts
+++ b/src/parsers/json.ts
@@ -17,10 +17,12 @@ export class JsonParser extends Parser {
   }
 
   async dump(object: object, sort: boolean) {
+    const indent = this.options.tab === '\t' ? this.options.tab : this.options.indent
+
     if (sort)
-      return `${SortedStringify(object, { space: this.options.indent })}\n`
+      return `${SortedStringify(object, { space: indent })}\n`
     else
-      return `${JSON.stringify(object, null, this.options.indent)}\n`
+      return `${JSON.stringify(object, null, indent)}\n`
   }
 
   annotationSupported = true

--- a/src/parsers/json5.ts
+++ b/src/parsers/json5.ts
@@ -17,7 +17,7 @@ export class Json5Parser extends Parser {
 
   async dump(object: object, sort: boolean) {
     return JSON5.stringify(object, {
-      space: this.options.indent,
+      space: this.options.tab === '\t' ? this.options.tab : this.options.indent,
     })
   }
 


### PR DESCRIPTION
This PR updates JSON (and JSON5) parsers to respect `tabStyle` option, so it should fix #337.

This is the simplest solution I could think of, it may not be perfect and I'm open to suggestions to improve it.