### PR TITLE
add support for {fileName} variable in config.keyPrefix

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -43,7 +43,7 @@
   "config.include_subfolders": "Search recursively inside locale directories",
   "config.indent": "Indent space size for locale files",
   "config.keep_fulfill": "Always keep all keys fulfilled with empty strings",
-  "config.key_prefix": "String prepend to the extracting key.",
+  "config.key_prefix": "String to prepend to the extracting key. You can use {fileName} for the file name, and {fileNameWithoutExt} for the part of the file name before the first dot.",
   "config.keygen_strategy": "Strategy of generating key.",
   "config.keys_in_use": "Keys to mark as in use despite not appearing in the code",
   "config.keystyle": "Locale key style",

--- a/src/commands/extractText.ts
+++ b/src/commands/extractText.ts
@@ -1,6 +1,7 @@
 import { commands, window, workspace, QuickPickItem } from 'vscode'
 // @ts-ignore
 import * as limax from 'limax'
+import * as path from "path";
 import { trim } from 'lodash'
 import { nanoid } from 'nanoid'
 import { ExtensionModule } from '../modules'
@@ -36,10 +37,14 @@ const m: ExtensionModule = () => {
       const locale = Config.sourceLanguage
       const loader = CurrentFile.loader
       const { filepath, text, range, languageId } = options
+      const fileName = path.basename(filepath)
+      const fileNameWithoutExt = path.basename(filepath, path.extname(filepath))
       const cleanedText = trim(text, '\'" ')
       let default_keypath: string
       const keygenStrategy = Config.keygenStrategy
       const keyPrefix = Config.keyPrefix
+        .replace('{fileName}', fileName)
+        .replace('{fileNameWithoutExt}', fileNameWithoutExt)
 
       const existingItems: QuickPickItemWithKey[]
         = loader.keys


### PR DESCRIPTION
Hi, thank you for this amazing extension!

This PR makes `config.keyPrefix` a bit more powerful - it will replace `{fileName}` with the current file name, and `{fileNameWithoutExt}` with the current file name without the extension.

#### Example:

Your vscode config includes:
```json
  "i18n-ally.extract.keyPrefix": "{fileNameWithoutExt}.",
```

If you have a file called `MyFile.js` and extract the text "Hello World", the suggested key will be `MyFile.hello-world`.