### PR TITLE
add extract.keyMaxLength option

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -44,7 +44,7 @@
   "config.indent": "Indent space size for locale files",
   "config.keep_fulfill": "Always keep all keys fulfilled with empty strings",
   "config.key_prefix": "String to prepend to the extracting key. You can use {fileName} for the file name, and {fileNameWithoutExt} for the part of the file name before the first dot.",
-  "config.key_max_length": "If specified, the key will be truncated to this number of characters (excluding the keyPrefix). Defaults to no limit",
+  "config.key_max_length": "If specified, the generated key on extracting will be truncated to this number of characters (excluding the keyPrefix). Defaults to unlimited.",
   "config.keygen_strategy": "Strategy of generating key.",
   "config.keys_in_use": "Keys to mark as in use despite not appearing in the code",
   "config.keystyle": "Locale key style",

--- a/locales/en.json
+++ b/locales/en.json
@@ -44,6 +44,7 @@
   "config.indent": "Indent space size for locale files",
   "config.keep_fulfill": "Always keep all keys fulfilled with empty strings",
   "config.key_prefix": "String to prepend to the extracting key. You can use {fileName} for the file name, and {fileNameWithoutExt} for the part of the file name before the first dot.",
+  "config.key_max_length": "If specified, the key will be truncated to this number of characters (excluding the keyPrefix). Defaults to no limit",
   "config.keygen_strategy": "Strategy of generating key.",
   "config.keys_in_use": "Keys to mark as in use despite not appearing in the code",
   "config.keystyle": "Locale key style",

--- a/package.json
+++ b/package.json
@@ -851,6 +851,11 @@
           "default": "",
           "description": "%config.key_prefix%"
         },
+        "i18n-ally.extract.keyMaxLength": {
+          "type": "number",
+          "default": null,
+          "description": "%config.key_max_length%"
+        },
         "i18n-ally.extract.targetPickingStrategy": {
           "type": "string",
           "default": "none",

--- a/src/commands/extractText.ts
+++ b/src/commands/extractText.ts
@@ -38,7 +38,7 @@ async function ExtractOrInsertCommnad(options?: ExtractTextOptions) {
   const { filepath, text, range, languageId, isInsert } = options
   const fileName = path.basename(filepath)
   const fileNameWithoutExt = path.basename(filepath, path.extname(filepath))
-  const cleanedText = trim(text, '\'" ')
+  const cleanedText = trim(text, '\'"` ')
   let default_keypath: string
   const keygenStrategy = Config.keygenStrategy
   const keyPrefix = Config.keyPrefix
@@ -62,12 +62,16 @@ async function ExtractOrInsertCommnad(options?: ExtractTextOptions) {
           detail: i18n.t('prompt.existing_translation'),
         }))
 
-  if (keygenStrategy === 'random')
+  if (keygenStrategy === 'random') {
     default_keypath = nanoid()
-  else if (keygenStrategy === 'empty')
+  }
+  else if (keygenStrategy === 'empty') {
     default_keypath = ''
-  else
-    default_keypath = limax(text, { separator: Config.preferredDelimiter, tone: false }) as string
+  }
+  else {
+    default_keypath = limax(text, { separator: Config.preferredDelimiter, tone: false })
+      .slice(0, Config.keyMaxLength ?? Infinity)
+  }
 
   if (keyPrefix && keygenStrategy !== 'empty' && !isInsert)
     default_keypath = keyPrefix + default_keypath

--- a/src/commands/extractText.ts
+++ b/src/commands/extractText.ts
@@ -70,7 +70,7 @@ async function ExtractOrInsertCommnad(options?: ExtractTextOptions) {
   }
   else {
     default_keypath = limax(text, { separator: Config.preferredDelimiter, tone: false })
-      .slice(0, Config.keyMaxLength ?? Infinity)
+      .slice(0, Config.extractKeyMaxLength ?? Infinity)
   }
 
   if (keyPrefix && keygenStrategy !== 'empty' && !isInsert)

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -390,6 +390,10 @@ export class Config {
     return this.getConfig<string>('extract.keyPrefix') ?? ''
   }
 
+  static get keyMaxLength() {
+    return this.getConfig<number>('extract.keyMaxLength') ?? Infinity
+  }
+
   static get showFlags() {
     return this.getConfig<boolean>('showFlags') ?? true
   }

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -390,7 +390,7 @@ export class Config {
     return this.getConfig<string>('extract.keyPrefix') ?? ''
   }
 
-  static get keyMaxLength() {
+  static get extractKeyMaxLength() {
     return this.getConfig<number>('extract.keyMaxLength') ?? Infinity
   }
 


### PR DESCRIPTION
Hi!

This PR adds an option to limit the length of the extracted key.

For instance, if you select a huge paragraph of text, and set `i18n-ally.extract.keyMaxLength` to `30`, then the key will be truncated to 30 characters (not counting the keyPrefix)


(also, I added ` `` ` as a character that should be trimmed about when extracting text because it's used as a quote in some languages)