### PR TITLE
feat: add fluter_i18n text widget shorthand

### DIFF
--- a/src/frameworks/flutter.ts
+++ b/src/frameworks/flutter.ts
@@ -18,6 +18,7 @@ class FlutterFramework extends Framework {
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
     '[^\\w\\d]FlutterI18n\\.(?:plural|translate)\\([\\w\\d]+,[\\s\\n]?[\'"`]({key})[\'"`]',
+    '[^\\w\\d]I18n(?:Plural|Text)\\([\\s\\n]?[\'"`]({key})[\'"`]',
   ]
 
   refactorTemplates(keypath: string) {


### PR DESCRIPTION
Hello,
_flutter_i18n_ supports not only `FlutterI18n.translate` but also some text widgets :
```dart
I18nText("your.key", child: Text(""))
I18nText("your.key", translationParams: {"user": "Flutter lover"})
I18nPlural("clicked.times", 1)
I18nPlural("clicked.times", 2, child: Text(""))
```
Here is an attempt to add support for them as well.
