### PR TITLE
fix(flutter) multiline regex at any place

### DIFF
--- a/src/frameworks/flutter.ts
+++ b/src/frameworks/flutter.ts
@@ -17,8 +17,8 @@ class FlutterFramework extends Framework {
 
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
-    '[^\\w\\d]FlutterI18n\\.(?:plural|translate)\\([\\w\\d]+,[\\s\\n]?[\'"`]({key})[\'"`]',
-    '[^\\w\\d]I18n(?:Plural|Text)\\([\\s\\n]?[\'"`]({key})[\'"`]',
+    '[^\\w\\d]FlutterI18n\\.(?:plural|translate)\\(\\s*[\\w\\d]+,\\s*[\'"`]({key})[\'"`]',
+    '[^\\w\\d]I18n(?:Plural|Text)\\(\\s*[\'"`]({key})[\'"`]',
   ]
 
   refactorTemplates(keypath: string) {


### PR DESCRIPTION
fix #344
Support breaking line after `(` or `context,` : 

```dart
TextFormField(
  decoration: InputDecoration(
    border: OutlineInputBorder(),
    labelText: FlutterI18n.translate(
        context, "settings.authentication.token.label"),
),
```
In my files the second option (breaking after the comma) is never used by dartfm.